### PR TITLE
hardcode version in AC_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([UnitTest++],
-        m4_esyscmd_s([git describe --tags | cut -c2-]),
+        [2.1.0],
         [pjohnmeyer@gmail.com],
         [unittest-cpp])
 


### PR DESCRIPTION
If the .so version is hard coded it doesn't make sense to dynamically set the version in AC_INIT. Additionally in a released tar.gz version, the sources are not a git repository and therefore the call to `git describe ...` won't work.